### PR TITLE
Give extra permissions

### DIFF
--- a/RunAsTI.ps1
+++ b/RunAsTI.ps1
@@ -39,7 +39,7 @@ function RunAsTI ($cmd,$arg) { $id='RunAsTI'; $key="Registry::HKU\$(((whoami /us
  $A2.f6=$A1; $A3.f1=10*$Z+32; $A4.f1=$A3; $A4.f2=$H[1]; M "StructureTo`Ptr" ($D[2],$P,[boolean]) (($A2 -as $D[2]),$A4.f2,$false)
  $Run=@($null, "powershell -win 1 -nop -c iex `$env:R; # $id", 0, 0, 0, 0x0E080600, 0, $null, ($A4 -as $T[4]), ($A5 -as $T[5]))
  F 'CreateProcess' $Run; return}; $env:R=''; rp $key $id -force; $priv=[diagnostics.process]."GetM`ember"('SetPrivilege',42)[0]   
- 'SeSecurityPrivilege','SeTakeOwnershipPrivilege','SeBackupPrivilege','SeRestorePrivilege' |% {$priv.Invoke($null, @("$_",2))}
+ 'SeSecurityPrivilege','SeTakeOwnershipPrivilege','SeBackupPrivilege','SeRestorePrivilege','SeImpersonatePrivilege', 'SeDebugPrivilege', 'SeLoadDriverPrivilege', 'SeSecurityPrivilege', 'SeAssignPrimaryTokenPrivilege', 'SeTcbPrivilege', 'SeIncreaseBasePriorityPrivilege', 'SeSystemEnvironmentPrivilege' |% {$priv.Invoke($null, @("$_",2))}
  $HKU=[uintptr][uint32]2147483651; $NT='S-1-5-18'; $reg=($HKU,$NT,8,2,($HKU -as $D[9])); F 'RegOpenKeyEx' $reg; $LNK=$reg[4]
  function L ($1,$2,$3) {sp 'HKLM:\Software\Classes\AppID\{CDCBCFCA-3CDC-436f-A4E2-0E02075250C2}' 'RunAs' $3 -force -ea 0
   $b=[Text.Encoding]::Unicode.GetBytes("\Registry\User\$1"); F 'RegSetValueEx' @($2,'SymbolicLinkValue',0,6,[byte[]]$b,$b.Length)}


### PR DESCRIPTION
On Windows 10 (19044) administrator is required to run this script wether this change is present or not.
Before this change you could not terminate MsMpEng or edit the registry values.
Is this expected behaviour or perhaps specific to my Windows 10 version?
Now you can, as well as LSASS etc with no additional requirements.
Still have issues writing to memory, perhaps there are additional permissions needed